### PR TITLE
fix(checks): Process all open PRs in each run

### DIFF
--- a/ruciobot/checks/base.py
+++ b/ruciobot/checks/base.py
@@ -2,13 +2,25 @@
 Abstract base class for all RucioBot checks.
 """
 
+import time
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 
 from github import Github
+from github.GithubException import GithubException, RateLimitExceededException
+from github.PullRequest import PullRequest
+from github.Repository import Repository
 
 # PRs carrying this label are completely skipped by all bot checks.
 NO_BOT_LABEL = "no-bot"
+
+# Secondary-rate-limit backoff. When GitHub rejects a write because too many
+# mutating requests were made in a short window it returns a 403 (raised by
+# PyGithub as RateLimitExceededException), usually with a Retry-After header.
+# We wait and retry the same PR a few times before giving up on it.
+MAX_SECONDARY_RATE_LIMIT_RETRIES = 3
+DEFAULT_RETRY_AFTER_SECONDS = 60
+MAX_RETRY_AFTER_SECONDS = 300  # cap, so an oversized Retry-After cannot hang the job
 
 
 def is_excluded_from_bot(pr) -> bool:
@@ -35,11 +47,115 @@ def count_business_days(start: datetime, end: datetime) -> int:
 
 class BaseCheck(ABC):
     """
-    Every check must implement `run`. The CLI calls run(gh, repo_name)
-    without needing to know anything about the check's internals.
+    Base class for all checks.
+
+    Subclasses implement :meth:`process` for a single PR. This class owns the
+    shared loop: it fetches the open PRs and runs ``process`` on each one,
+    isolating per-PR failures so one bad PR cannot abort the whole sweep.
     """
 
-    @abstractmethod
+    #: Short message printed when the check starts (overridden per check).
+    summary: str = "Running check"
+
     def run(self, gh: Github, repo_name: str) -> None:
-        """Execute the check against the given repository."""
+        print(f"{self.summary} in {repo_name}...")
+        repo = gh.get_repo(repo_name)
+
+        # Materialise the full list of open PRs *before* processing any of them.
+        # The checks mutate PRs (posting comments, adding or removing labels),
+        # which bumps each PR's ``updated_at``. GitHub returns ``get_pulls`` as a
+        # lazily-paginated list that is re-sorted server-side on every page fetch,
+        # and the "next page" link is offset-based rather than a stable cursor.
+        # Mutating PRs while iterating therefore shifts later pages and silently
+        # skips PRs across page boundaries. Pulling every page up front, while
+        # nothing has changed yet, gives a stable snapshot; the in-memory order
+        # is then irrelevant to correctness.
+        pulls = list(repo.get_pulls(state="open"))
+
+        for pr in pulls:
+            keep_going = self._process_pr_safely(pr, repo)
+            if not keep_going:
+                break
+
+    def _process_pr_safely(self, pr: PullRequest, repo: Repository) -> bool:
+        """Run :meth:`process` on a single PR with error isolation.
+
+        A failure on one PR (a transient API error, or a secondary rate limit
+        triggered by rapid comment creation) must never abort the whole sweep.
+
+        Returns ``True`` to continue with the next PR, or ``False`` to stop the
+        run entirely. We only stop when the *primary* rate limit is exhausted,
+        since no further request can succeed until it resets.
+        """
+        for attempt in range(MAX_SECONDARY_RATE_LIMIT_RETRIES + 1):
+            try:
+                self.process(pr, repo)
+                return True
+            except RateLimitExceededException as exc:
+                wait_seconds = _secondary_rate_limit_wait(exc)
+                if wait_seconds is None:
+                    # Primary rate limit: nothing will succeed until it resets.
+                    print("  [RATE-LIMIT] Primary rate limit reached. Stopping this run.")
+                    return False
+                if attempt >= MAX_SECONDARY_RATE_LIMIT_RETRIES:
+                    print(
+                        f"  [RATE-LIMIT] Still limited after {attempt} retries; "
+                        f"skipping PR #{pr.number}."
+                    )
+                    return True
+                print(
+                    f"  [RATE-LIMIT] Secondary rate limit on PR #{pr.number}; "
+                    f"waiting {wait_seconds}s before retrying."
+                )
+                time.sleep(wait_seconds)
+            except GithubException as exc:
+                print(f"  [ERROR] GitHub error on PR #{pr.number}; skipping. {exc}")
+                return True
+            except Exception as exc:
+                print(f"  [ERROR] Unexpected error on PR #{pr.number}; skipping. {exc}")
+                return True
+        return True
+
+    @abstractmethod
+    def process(self, pr: PullRequest, repo: Repository) -> None:
+        """Apply this check's logic to a single PR."""
         ...
+
+
+def _secondary_rate_limit_wait(exc: GithubException) -> int | None:
+    """Seconds to wait for a *secondary* rate-limit error.
+
+    Returns ``None`` when *exc* is not a secondary rate limit (e.g. a primary
+    rate limit), signalling that retrying the same request is pointless.
+    """
+    message = exc.data.get("message", "") if isinstance(exc.data, dict) else ""
+    retry_after = _get_header(exc.headers, "retry-after")
+    if not _is_secondary_rate_limit(str(message)) and retry_after is None:
+        return None
+    if retry_after is not None:
+        try:
+            return min(int(retry_after), MAX_RETRY_AFTER_SECONDS)
+        except (TypeError, ValueError):
+            pass
+    return DEFAULT_RETRY_AFTER_SECONDS
+
+
+def _is_secondary_rate_limit(message: str) -> bool:
+    """Match GitHub's secondary-rate-limit messages (mirrors PyGithub)."""
+    text = message.lower()
+    return (
+        text.startswith("you have exceeded a secondary rate limit")
+        or text.endswith("please retry your request again later.")
+        or text.endswith("please wait a few minutes before you try again.")
+    )
+
+
+def _get_header(headers: dict | None, name: str) -> str | None:
+    """Case-insensitive header lookup."""
+    if not headers:
+        return None
+    target = name.lower()
+    for key, value in headers.items():
+        if key.lower() == target:
+            return value
+    return None

--- a/ruciobot/checks/failing_tests.py
+++ b/ruciobot/checks/failing_tests.py
@@ -4,8 +4,8 @@ Failing-tests check: warn after WARN_DAYS of inactivity, close after CLOSE_DAYS 
 
 from datetime import UTC, datetime
 
-from github import Github
 from github.PullRequest import PullRequest
+from github.Repository import Repository
 
 from .base import NO_BOT_LABEL, BaseCheck, count_business_days, is_excluded_from_bot
 
@@ -17,12 +17,10 @@ FAILING_TESTS_CLOSE_DAYS = 3  # Days of inactivity (after warning) before closin
 class FailingTestsCheck(BaseCheck):
     """Warns and closes PRs that have failing CI checks and remain inactive."""
 
-    def run(self, gh: Github, repo_name: str) -> None:
-        print(f"Checking {repo_name} for PRs with failing tests...")
-        repo = gh.get_repo(repo_name)
-        pulls = repo.get_pulls(state="open", sort="updated", direction="asc")
-        for pr in pulls:
-            process_failing_test_pr(pr, repo)
+    summary = "Checking for PRs with failing tests"
+
+    def process(self, pr: PullRequest, repo: Repository) -> None:
+        process_failing_test_pr(pr, repo)
 
 
 # Helpers

--- a/ruciobot/checks/needs_rebase.py
+++ b/ruciobot/checks/needs_rebase.py
@@ -2,8 +2,8 @@
 Needs-rebase check: comment on PRs that cannot be merged due to conflicts.
 """
 
-from github import Github
 from github.PullRequest import PullRequest
+from github.Repository import Repository
 
 from .base import NO_BOT_LABEL, BaseCheck, is_excluded_from_bot
 
@@ -20,12 +20,10 @@ REBASE_COMMENT = (
 class NeedsRebaseCheck(BaseCheck):
     """Comments on and labels PRs that have merge conflicts."""
 
-    def run(self, gh: Github, repo_name: str) -> None:
-        print(f"Checking {repo_name} for PRs that need rebasing...")
-        repo = gh.get_repo(repo_name)
-        pulls = repo.get_pulls(state="open", sort="updated", direction="asc")
-        for pr in pulls:
-            process_needs_rebase_pr(pr)
+    summary = "Checking for PRs that need rebasing"
+
+    def process(self, pr: PullRequest, repo: Repository) -> None:
+        process_needs_rebase_pr(pr)
 
 
 # Helpers

--- a/ruciobot/checks/stale_prs.py
+++ b/ruciobot/checks/stale_prs.py
@@ -4,8 +4,8 @@ Stale PR check: warn after WARN_DAYS of inactivity, close after CLOSE_DAYS more.
 
 from datetime import UTC, datetime
 
-from github import Github
 from github.PullRequest import PullRequest
+from github.Repository import Repository
 
 from .base import NO_BOT_LABEL, BaseCheck, count_business_days, is_excluded_from_bot
 
@@ -17,15 +17,13 @@ CLOSE_DAYS = 7  # Days after warning to close
 class StalePRCheck(BaseCheck):
     """Marks inactive PRs as stale and closes them if they remain inactive."""
 
+    summary = "Checking for stale PRs"
+
     def __init__(self, days_until_stale: int = WARN_DAYS):
         self.days_until_stale = days_until_stale
 
-    def run(self, gh: Github, repo_name: str) -> None:
-        print(f"Checking {repo_name} for stale PRs...")
-        repo = gh.get_repo(repo_name)
-        pulls = repo.get_pulls(state="open", sort="updated", direction="asc")
-        for pr in pulls:
-            process_pr(pr, self.days_until_stale)
+    def process(self, pr: PullRequest, repo: Repository) -> None:
+        process_pr(pr, self.days_until_stale)
 
 
 # Helpers

--- a/tests/checks/test_base_run.py
+++ b/tests/checks/test_base_run.py
@@ -1,0 +1,172 @@
+"""
+Tests for the shared ``BaseCheck.run`` loop.
+
+These cover the cross-cutting behaviour that lives in the base class rather than
+in any individual check:
+
+  * the open PRs are snapshotted (pagination fully consumed) *before* any PR is
+    processed, so mutating a PR mid-run cannot reorder later pages and skip PRs;
+  * a failure on one PR does not abort the rest of the sweep;
+  * a secondary rate limit is retried after backing off, and a primary rate
+    limit stops the run.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from github.GithubException import RateLimitExceededException
+
+from ruciobot.checks.base import MAX_SECONDARY_RATE_LIMIT_RETRIES, BaseCheck
+
+
+def _make_pr(number):
+    pr = MagicMock()
+    pr.number = number
+    return pr
+
+
+class RecordingPulls:
+    """Mimics a PaginatedList: yields PRs lazily and records when each is pulled.
+
+    Used to prove that ``run`` exhausts pagination before processing any PR.
+    """
+
+    def __init__(self, prs, log):
+        self._prs = prs
+        self._log = log
+
+    def __iter__(self):
+        for pr in self._prs:
+            self._log.append(("fetched", pr.number))
+            yield pr
+
+
+class DummyCheck(BaseCheck):
+    """A check whose per-PR behaviour is scripted for testing."""
+
+    summary = "dummy check"
+
+    def __init__(self, log, behaviour=None):
+        self.log = log
+        self.behaviour = behaviour or {}
+
+    def process(self, pr, repo):
+        self.log.append(("processed", pr.number))
+        action = self.behaviour.get(pr.number)
+        if action is not None:
+            action()
+
+
+def _make_gh(prs, log):
+    repo = MagicMock()
+    repo.get_pulls.return_value = RecordingPulls(prs, log)
+    gh = MagicMock()
+    gh.get_repo.return_value = repo
+    return gh, repo
+
+
+def _secondary_exc(retry_after="1"):
+    headers = {"retry-after": retry_after} if retry_after is not None else {}
+    return RateLimitExceededException(
+        403,
+        {"message": "You have exceeded a secondary rate limit."},
+        headers,
+        None,
+    )
+
+
+def _primary_exc():
+    return RateLimitExceededException(
+        403, {"message": "API rate limit exceeded for user 123."}, {}, None
+    )
+
+
+class TestBaseRun(unittest.TestCase):
+    def test_fetches_all_open_prs_before_processing_any(self):
+        """run() must snapshot every open PR before mutating, so none is skipped."""
+        log = []
+        prs = [_make_pr(1), _make_pr(2), _make_pr(3)]
+        gh, repo = _make_gh(prs, log)
+
+        DummyCheck(log).run(gh, "rucio/rucio")
+
+        repo.get_pulls.assert_called_once_with(state="open")
+        # Every "fetched" entry must precede the first "processed" entry.
+        kinds = [kind for kind, _ in log]
+        first_processed = kinds.index("processed")
+        self.assertNotIn("fetched", kinds[first_processed:])
+        # And all three PRs were processed.
+        processed = [n for kind, n in log if kind == "processed"]
+        self.assertEqual(processed, [1, 2, 3])
+
+    def test_one_pr_failure_does_not_abort_the_sweep(self):
+        """A generic error on one PR must not stop the others from processing."""
+        log = []
+        prs = [_make_pr(1), _make_pr(2), _make_pr(3)]
+        gh, _ = _make_gh(prs, log)
+
+        def boom():
+            raise ValueError("kaboom")
+
+        DummyCheck(log, behaviour={2: boom}).run(gh, "rucio/rucio")
+
+        processed = [n for kind, n in log if kind == "processed"]
+        self.assertEqual(processed, [1, 2, 3])
+
+    @patch("ruciobot.checks.base.time.sleep")
+    def test_retries_then_succeeds_on_secondary_rate_limit(self, mock_sleep):
+        """A secondary rate limit is retried after backing off, then succeeds."""
+        log = []
+        prs = [_make_pr(1), _make_pr(2)]
+        gh, _ = _make_gh(prs, log)
+
+        state = {"raised": False}
+
+        def flaky():
+            if not state["raised"]:
+                state["raised"] = True
+                raise _secondary_exc(retry_after="1")
+
+        DummyCheck(log, behaviour={1: flaky}).run(gh, "rucio/rucio")
+
+        mock_sleep.assert_called_once_with(1)
+        processed = [n for kind, n in log if kind == "processed"]
+        # PR 1 processed twice (initial failure + successful retry), PR 2 once.
+        self.assertEqual(processed, [1, 1, 2])
+
+    @patch("ruciobot.checks.base.time.sleep")
+    def test_persistent_secondary_limit_skips_pr_and_continues(self, mock_sleep):
+        """If a PR keeps hitting the secondary limit, skip it and move on."""
+        log = []
+        prs = [_make_pr(1), _make_pr(2)]
+        gh, _ = _make_gh(prs, log)
+
+        def always():
+            raise _secondary_exc(retry_after="1")
+
+        DummyCheck(log, behaviour={1: always}).run(gh, "rucio/rucio")
+
+        self.assertEqual(mock_sleep.call_count, MAX_SECONDARY_RATE_LIMIT_RETRIES)
+        # PR 2 is still processed despite PR 1 exhausting its retries.
+        self.assertIn(2, [n for kind, n in log if kind == "processed"])
+
+    @patch("ruciobot.checks.base.time.sleep")
+    def test_primary_rate_limit_stops_the_run(self, mock_sleep):
+        """A primary rate limit halts the sweep, since nothing else can succeed."""
+        log = []
+        prs = [_make_pr(1), _make_pr(2), _make_pr(3)]
+        gh, _ = _make_gh(prs, log)
+
+        def primary():
+            raise _primary_exc()
+
+        DummyCheck(log, behaviour={2: primary}).run(gh, "rucio/rucio")
+
+        mock_sleep.assert_not_called()
+        processed = [n for kind, n in log if kind == "processed"]
+        # PR 1 and PR 2 attempted; PR 3 never reached.
+        self.assertEqual(processed, [1, 2])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Each check fetched open PRs with get_pulls(sort="updated", direction="asc") and iterated the lazily-paginated result while commenting on and labelling PRs. Every mutation bumps a PR's updated_at, so GitHub re-sorts the list, and because pages are offset-based (30 per page) PRs shift across page boundaries and are silently skipped once more than 30 PRs are open. Separately, an unhandled error on a single PR, such as a secondary rate limit from rapid comment creation, aborted the whole run, so the bot could act on only the first PR before stopping.

Move the shared loop into BaseCheck.run and have each check implement process(pr, repo). The loop now:

- fetches the full list of open PRs up front, giving a stable snapshot so mutations cannot reorder later pages and drop PRs;
- isolates per-PR failures so one PR cannot abort the sweep;
- backs off and retries on a secondary rate limit, honouring Retry-After (capped), and stops cleanly on a primary rate limit.

The per-PR process_* functions are unchanged. The explicit updated sort is dropped, as ordering no longer affects correctness.

Add tests/checks/test_base_run.py covering the snapshot, per-PR error isolation, and rate-limit handling.

Assisted-by: Claude Opus 4.8