### PR TITLE
Fix stale behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Responsible for PR merging in [rucio/ruciobot](https://github.com/rucio/ruciobot
 
 ## Checks
 
-**Stale PRs.** A pull request is marked stale after a configurable number of weekdays without activity. If the PR has pending review requests, it is skipped. Stale PRs that remain inactive are eventually closed.
+**Stale PRs.** After a configurable number of weekdays without activity, the bot decides who the PR is waiting on. A PR is only marked stale, and eventually closed, when it is waiting on its *author*: a reviewer has engaged and the author has not pushed or replied since. A PR that is waiting on the *maintainers* is never closed for inactivity. That covers a PR that has never been reviewed, one with a pending review request, and one where the author has already responded to the last review. These are surfaced with a `needs-review` label instead, so reviewers can find them. Approved PRs are left alone, as they are waiting on a merge.
 
 **Failing tests.** A pull request with failing CI checks is warned after one weekday of inactivity. If it remains inactive and labeled for three more weekdays, it is closed.
 

--- a/ruciobot/checks/base.py
+++ b/ruciobot/checks/base.py
@@ -2,13 +2,25 @@
 Abstract base class for all RucioBot checks.
 """
 
+import time
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 
 from github import Github
+from github.GithubException import GithubException, RateLimitExceededException
+from github.PullRequest import PullRequest
+from github.Repository import Repository
 
 # PRs carrying this label are completely skipped by all bot checks.
 NO_BOT_LABEL = "no-bot"
+
+# Secondary-rate-limit backoff. When GitHub rejects a write because too many
+# mutating requests were made in a short window it returns a 403 (raised by
+# PyGithub as RateLimitExceededException), usually with a Retry-After header.
+# We wait and retry the same PR a few times before giving up on it.
+MAX_SECONDARY_RATE_LIMIT_RETRIES = 3
+DEFAULT_RETRY_AFTER_SECONDS = 60
+MAX_RETRY_AFTER_SECONDS = 300  # cap, so an oversized Retry-After cannot hang the job
 
 
 def is_excluded_from_bot(pr) -> bool:
@@ -35,11 +47,115 @@ def count_business_days(start: datetime, end: datetime) -> int:
 
 class BaseCheck(ABC):
     """
-    Every check must implement `run`. The CLI calls run(gh, repo_name)
-    without needing to know anything about the check's internals.
+    Base class for all checks.
+
+    Subclasses implement :meth:`process` for a single PR. This class owns the
+    shared loop: it fetches the open PRs and runs ``process`` on each one,
+    isolating per-PR failures so one bad PR cannot abort the whole sweep.
     """
 
-    @abstractmethod
+    #: Short message printed when the check starts (overridden per check).
+    summary: str = "Running check"
+
     def run(self, gh: Github, repo_name: str) -> None:
-        """Execute the check against the given repository."""
+        print(f"{self.summary} in {repo_name}...")
+        repo = gh.get_repo(repo_name)
+
+        # Materialise the full list of open PRs *before* processing any of them.
+        # The checks mutate PRs (posting comments, adding or removing labels),
+        # which bumps each PR's ``updated_at``. GitHub returns ``get_pulls`` as a
+        # lazily-paginated list that is re-sorted server-side on every page fetch,
+        # and the "next page" link is offset-based rather than a stable cursor.
+        # Mutating PRs while iterating therefore shifts later pages and silently
+        # skips PRs across page boundaries. Pulling every page up front, while
+        # nothing has changed yet, gives a stable snapshot; the in-memory order
+        # is then irrelevant to correctness.
+        pulls = list(repo.get_pulls(state="open"))
+
+        for pr in pulls:
+            keep_going = self._process_pr_safely(pr, repo)
+            if not keep_going:
+                break
+
+    def _process_pr_safely(self, pr: PullRequest, repo: Repository) -> bool:
+        """Run :meth:`process` on a single PR with error isolation.
+
+        A failure on one PR (a transient API error, or a secondary rate limit
+        triggered by rapid comment creation) must never abort the whole sweep.
+
+        Returns ``True`` to continue with the next PR, or ``False`` to stop the
+        run entirely. We only stop when the *primary* rate limit is exhausted,
+        since no further request can succeed until it resets.
+        """
+        for attempt in range(MAX_SECONDARY_RATE_LIMIT_RETRIES + 1):
+            try:
+                self.process(pr, repo)
+                return True
+            except RateLimitExceededException as exc:
+                wait_seconds = _secondary_rate_limit_wait(exc)
+                if wait_seconds is None:
+                    # Primary rate limit: nothing will succeed until it resets.
+                    print("  [RATE-LIMIT] Primary rate limit reached. Stopping this run.")
+                    return False
+                if attempt >= MAX_SECONDARY_RATE_LIMIT_RETRIES:
+                    print(
+                        f"  [RATE-LIMIT] Still limited after {attempt} retries; "
+                        f"skipping PR #{pr.number}."
+                    )
+                    return True
+                print(
+                    f"  [RATE-LIMIT] Secondary rate limit on PR #{pr.number}; "
+                    f"waiting {wait_seconds}s before retrying."
+                )
+                time.sleep(wait_seconds)
+            except GithubException as exc:
+                print(f"  [ERROR] GitHub error on PR #{pr.number}; skipping. {exc}")
+                return True
+            except Exception as exc:
+                print(f"  [ERROR] Unexpected error on PR #{pr.number}; skipping. {exc}")
+                return True
+        return True
+
+    @abstractmethod
+    def process(self, pr: PullRequest, repo: Repository) -> None:
+        """Apply this check's logic to a single PR."""
         ...
+
+
+def _secondary_rate_limit_wait(exc: GithubException) -> int | None:
+    """Seconds to wait for a *secondary* rate-limit error.
+
+    Returns ``None`` when *exc* is not a secondary rate limit (e.g. a primary
+    rate limit), signalling that retrying the same request is pointless.
+    """
+    message = exc.data.get("message", "") if isinstance(exc.data, dict) else ""
+    retry_after = _get_header(exc.headers, "retry-after")
+    if not _is_secondary_rate_limit(str(message)) and retry_after is None:
+        return None
+    if retry_after is not None:
+        try:
+            return min(int(retry_after), MAX_RETRY_AFTER_SECONDS)
+        except (TypeError, ValueError):
+            pass
+    return DEFAULT_RETRY_AFTER_SECONDS
+
+
+def _is_secondary_rate_limit(message: str) -> bool:
+    """Match GitHub's secondary-rate-limit messages (mirrors PyGithub)."""
+    text = message.lower()
+    return (
+        text.startswith("you have exceeded a secondary rate limit")
+        or text.endswith("please retry your request again later.")
+        or text.endswith("please wait a few minutes before you try again.")
+    )
+
+
+def _get_header(headers: dict | None, name: str) -> str | None:
+    """Case-insensitive header lookup."""
+    if not headers:
+        return None
+    target = name.lower()
+    for key, value in headers.items():
+        if key.lower() == target:
+            return value
+    return None

--- a/ruciobot/checks/failing_tests.py
+++ b/ruciobot/checks/failing_tests.py
@@ -4,8 +4,8 @@ Failing-tests check: warn after WARN_DAYS of inactivity, close after CLOSE_DAYS 
 
 from datetime import UTC, datetime
 
-from github import Github
 from github.PullRequest import PullRequest
+from github.Repository import Repository
 
 from .base import NO_BOT_LABEL, BaseCheck, count_business_days, is_excluded_from_bot
 
@@ -17,12 +17,10 @@ FAILING_TESTS_CLOSE_DAYS = 3  # Days of inactivity (after warning) before closin
 class FailingTestsCheck(BaseCheck):
     """Warns and closes PRs that have failing CI checks and remain inactive."""
 
-    def run(self, gh: Github, repo_name: str) -> None:
-        print(f"Checking {repo_name} for PRs with failing tests...")
-        repo = gh.get_repo(repo_name)
-        pulls = repo.get_pulls(state="open", sort="updated", direction="asc")
-        for pr in pulls:
-            process_failing_test_pr(pr, repo)
+    summary = "Checking for PRs with failing tests"
+
+    def process(self, pr: PullRequest, repo: Repository) -> None:
+        process_failing_test_pr(pr, repo)
 
 
 # Helpers

--- a/ruciobot/checks/needs_rebase.py
+++ b/ruciobot/checks/needs_rebase.py
@@ -2,8 +2,8 @@
 Needs-rebase check: comment on PRs that cannot be merged due to conflicts.
 """
 
-from github import Github
 from github.PullRequest import PullRequest
+from github.Repository import Repository
 
 from .base import NO_BOT_LABEL, BaseCheck, is_excluded_from_bot
 
@@ -20,12 +20,10 @@ REBASE_COMMENT = (
 class NeedsRebaseCheck(BaseCheck):
     """Comments on and labels PRs that have merge conflicts."""
 
-    def run(self, gh: Github, repo_name: str) -> None:
-        print(f"Checking {repo_name} for PRs that need rebasing...")
-        repo = gh.get_repo(repo_name)
-        pulls = repo.get_pulls(state="open", sort="updated", direction="asc")
-        for pr in pulls:
-            process_needs_rebase_pr(pr)
+    summary = "Checking for PRs that need rebasing"
+
+    def process(self, pr: PullRequest, repo: Repository) -> None:
+        process_needs_rebase_pr(pr)
 
 
 # Helpers

--- a/ruciobot/checks/stale_prs.py
+++ b/ruciobot/checks/stale_prs.py
@@ -4,8 +4,8 @@ Stale PR check: warn after WARN_DAYS of inactivity, close after CLOSE_DAYS more.
 
 from datetime import UTC, datetime
 
-from github import Github
 from github.PullRequest import PullRequest
+from github.Repository import Repository
 
 from .base import NO_BOT_LABEL, BaseCheck, count_business_days, is_excluded_from_bot
 
@@ -17,15 +17,13 @@ CLOSE_DAYS = 7  # Days after warning to close
 class StalePRCheck(BaseCheck):
     """Marks inactive PRs as stale and closes them if they remain inactive."""
 
+    summary = "Checking for stale PRs"
+
     def __init__(self, days_until_stale: int = WARN_DAYS):
         self.days_until_stale = days_until_stale
 
-    def run(self, gh: Github, repo_name: str) -> None:
-        print(f"Checking {repo_name} for stale PRs...")
-        repo = gh.get_repo(repo_name)
-        pulls = repo.get_pulls(state="open", sort="updated", direction="asc")
-        for pr in pulls:
-            process_pr(pr, self.days_until_stale)
+    def process(self, pr: PullRequest, repo: Repository) -> None:
+        process_pr(pr, self.days_until_stale)
 
 
 # Helpers

--- a/ruciobot/checks/stale_prs.py
+++ b/ruciobot/checks/stale_prs.py
@@ -1,5 +1,13 @@
 """
-Stale PR check: warn after WARN_DAYS of inactivity, close after CLOSE_DAYS more.
+Stale PR check.
+
+A PR is only marked stale and eventually closed when it is waiting on its
+*author*: a reviewer has engaged and the author has not pushed or replied
+since. A PR that is waiting on the *maintainers* is never closed for
+inactivity. That covers a PR that has never been reviewed, one with a pending
+review request, and one where the author has already responded to the last
+review and is waiting for another look. Such PRs are surfaced with a
+``needs-review`` label so reviewers can pick them up.
 """
 
 from datetime import UTC, datetime
@@ -10,12 +18,20 @@ from github.Repository import Repository
 from .base import NO_BOT_LABEL, BaseCheck, count_business_days, is_excluded_from_bot
 
 STALE_LABEL = "stale"
+NEEDS_REVIEW_LABEL = "needs-review"
 WARN_DAYS = 14
-CLOSE_DAYS = 7  # Days after warning to close
+CLOSE_DAYS = 7  # Weekdays after the stale warning before the PR is closed.
+
+# Which side a PR is waiting on.
+AWAITING_REVIEW = "awaiting_review"  # waiting on the maintainers
+AUTHOR_BLOCKED = "author_blocked"  # waiting on the author
+APPROVED = "approved"  # waiting on a merge
+
+COMPONENT_LEADS = "https://rucio.github.io/documentation/component_leads"
 
 
 class StalePRCheck(BaseCheck):
-    """Marks inactive PRs as stale and closes them if they remain inactive."""
+    """Marks author-blocked PRs stale and closes them; labels review-blocked PRs."""
 
     summary = "Checking for stale PRs"
 
@@ -30,57 +46,114 @@ class StalePRCheck(BaseCheck):
 
 
 def process_pr(pr: PullRequest, days_until_stale: int) -> None:
-    """Process a single PR to check for staleness."""
+    """Apply the stale / needs-review logic to a single PR."""
     if is_excluded_from_bot(pr):
         print(f"  [SKIP] PR #{pr.number} has '{NO_BOT_LABEL}' label. Skipping.")
         return
+
     now = datetime.now(UTC)
     assert pr.updated_at is not None, f"PR #{pr.number} has no updated_at timestamp"
-    last_updated = pr.updated_at.replace(tzinfo=UTC)
+    inactive_days = count_business_days(_to_utc(pr.updated_at), now)
 
-    inactive_business_days = count_business_days(last_updated, now)
+    labeled_stale = _has_label(pr, STALE_LABEL)
+    labeled_needs_review = _has_label(pr, NEEDS_REVIEW_LABEL)
 
-    if _is_labeled_stale(pr):
-        # Activity resumed — lift the stale label instead of closing.
-        if _is_awaiting_review(pr) or _is_approved(pr):
-            _clear_stale_label(pr)
-        elif inactive_business_days >= CLOSE_DAYS:
+    # Determining the responsible side is API-heavy (reviews, commits, comments),
+    # so skip it until there is something to act on: either the PR has been
+    # inactive long enough, or it carries a bot label that may need clearing
+    # after fresh activity.
+    if inactive_days < days_until_stale and not labeled_stale and not labeled_needs_review:
+        return
+
+    court = _court_of_responsibility(pr)
+
+    if court != AUTHOR_BLOCKED:
+        # Not the author's turn, so this PR is never closed for staleness.
+        if labeled_stale:
+            _clear_label(pr, STALE_LABEL, "has new activity or is awaiting review")
+        if court == AWAITING_REVIEW:
+            if inactive_days >= days_until_stale and not labeled_needs_review:
+                _flag_awaiting_review(pr, inactive_days)
+        elif labeled_needs_review:
+            # APPROVED: it is now waiting on a merge, not a review.
+            _clear_label(pr, NEEDS_REVIEW_LABEL, "is approved")
+        return
+
+    # The author owes a response.
+    if labeled_needs_review:
+        _clear_label(pr, NEEDS_REVIEW_LABEL, "is now waiting on the author")
+
+    if labeled_stale:
+        if inactive_days >= CLOSE_DAYS:
             _close_stale_pr(pr)
-    else:
-        if inactive_business_days >= days_until_stale:
-            if _is_awaiting_review(pr):
-                print(f"  [SKIP] PR #{pr.number} is awaiting reviewer response. Skipping.")
-            elif _is_approved(pr):
-                print(f"  [SKIP] PR #{pr.number} has an approved review. Skipping.")
-            else:
-                _mark_pr_stale(pr, days_until_stale)
+    elif inactive_days >= days_until_stale:
+        _mark_pr_stale(pr, days_until_stale)
 
 
-def _is_labeled_stale(pr: PullRequest) -> bool:
-    return STALE_LABEL in [lbl.name for lbl in pr.labels]
+def _court_of_responsibility(pr: PullRequest) -> str:
+    """Decide whether an open PR is waiting on the author, the maintainers, or a merge.
+
+    - ``APPROVED``: an approving review exists, so it is waiting on a merge.
+    - ``AUTHOR_BLOCKED``: a reviewer engaged more recently than the author last
+      pushed or commented, so the author owes a response.
+    - ``AWAITING_REVIEW``: anything else (never reviewed, a pending review
+      request, or the author acted most recently), so it is waiting on review.
+    """
+    author = _login(pr.user)
+    reviews = _safe_list(pr.get_reviews, "reviews")
+
+    if any(r.state == "APPROVED" and _is_other(r, author) for r in reviews):
+        return APPROVED
+
+    if _has_pending_review_request(pr):
+        return AWAITING_REVIEW
+
+    review_times = [
+        _to_utc(r.submitted_at)
+        for r in reviews
+        if r.state in ("CHANGES_REQUESTED", "COMMENTED")
+        and _is_other(r, author)
+        and r.submitted_at is not None
+    ]
+    last_review = max(review_times, default=None)
+    if last_review is None:
+        return AWAITING_REVIEW  # never substantively reviewed
+
+    last_author = _last_author_activity(pr, author)
+    if last_author is None or last_author >= last_review:
+        return AWAITING_REVIEW  # the author acted most recently
+
+    return AUTHOR_BLOCKED
 
 
-def _is_awaiting_review(pr: PullRequest) -> bool:
-    users_requested, teams_requested = pr.get_review_requests()
-    return users_requested.totalCount > 0 or teams_requested.totalCount > 0
+def _last_author_activity(pr: PullRequest, author: str | None) -> datetime | None:
+    """Most recent time the author pushed a commit or left a comment."""
+    times: list[datetime] = []
+    for commit in _safe_list(pr.get_commits, "commits"):
+        committer = commit.commit.committer if commit.commit else None
+        if committer is not None and committer.date is not None:
+            times.append(_to_utc(committer.date))
+    for comment in _safe_list(pr.get_issue_comments, "comments"):
+        if _is_author(comment, author) and comment.created_at is not None:
+            times.append(_to_utc(comment.created_at))
+    return max(times, default=None)
 
 
-def _is_approved(pr: PullRequest) -> bool:
-    """Return True if the PR has at least one approved review."""
-    return any(review.state == "APPROVED" for review in pr.get_reviews())
-
-
-def _clear_stale_label(pr: PullRequest) -> None:
-    print(f"  [INFO] PR #{pr.number} has new activity. Removing '{STALE_LABEL}' label.")
-    pr.remove_from_labels(STALE_LABEL)
+def _flag_awaiting_review(pr: PullRequest, inactive_days: int) -> None:
+    """Label a review-blocked PR so reviewers can find it (no comment is posted)."""
+    print(
+        f"  [REVIEW] PR #{pr.number} has waited {inactive_days} weekdays for review. "
+        f"Labeling '{NEEDS_REVIEW_LABEL}'."
+    )
+    pr.add_to_labels(NEEDS_REVIEW_LABEL)
 
 
 def _mark_pr_stale(pr: PullRequest, days: int) -> None:
     print(f"  [WARN] PR #{pr.number} is inactive for {days}+ weekdays. Marking stale.")
     pr.create_issue_comment(
-        f"This PR has had no activity for {days} weekdays and has no pending review requests. "
-        f"It has been marked as **stale** and will be closed in {CLOSE_DAYS} weekdays unless "
-        f"there is new activity or a reviewer is assigned."
+        f"This PR has had no activity for {days} weekdays and is waiting on its author. "
+        f"It has been marked as **stale** and will be closed in {CLOSE_DAYS} weekdays "
+        "unless there is new activity."
     )
     pr.add_to_labels(STALE_LABEL)
 
@@ -91,7 +164,51 @@ def _close_stale_pr(pr: PullRequest) -> None:
         "Closing this PR due to prolonged inactivity. "
         "Feel free to reopen it if you would like to continue working on it. "
         "If you believe this action was a mistake, please reach out to a member of the "
-        "[Rucio review team](https://rucio.github.io/documentation/component_leads) "
-        "with an explanation."
+        f"[Rucio review team]({COMPONENT_LEADS}) with an explanation."
     )
     pr.edit(state="closed")
+
+
+# Small GitHub helpers
+
+
+def _has_label(pr: PullRequest, label: str) -> bool:
+    return label in [lbl.name for lbl in pr.labels]
+
+
+def _clear_label(pr: PullRequest, label: str, reason: str) -> None:
+    print(f"  [INFO] PR #{pr.number} {reason}. Removing '{label}' label.")
+    pr.remove_from_labels(label)
+
+
+def _has_pending_review_request(pr: PullRequest) -> bool:
+    users_requested, teams_requested = pr.get_review_requests()
+    return users_requested.totalCount > 0 or teams_requested.totalCount > 0
+
+
+def _login(user) -> str | None:
+    return user.login if user else None
+
+
+def _is_other(obj, author: str | None) -> bool:
+    """True if obj (a review/comment) was made by someone other than the author."""
+    login = _login(getattr(obj, "user", None))
+    return login is not None and login != author
+
+
+def _is_author(obj, author: str | None) -> bool:
+    """True if obj (a review/comment) was made by the PR author."""
+    return author is not None and _login(getattr(obj, "user", None)) == author
+
+
+def _safe_list(getter, label: str) -> list:
+    """Call a PyGithub list endpoint, returning [] on any error."""
+    try:
+        return list(getter())
+    except Exception as e:
+        print(f"  [WARN] Could not fetch {label}: {e}")
+        return []
+
+
+def _to_utc(dt: datetime) -> datetime:
+    return dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt.astimezone(UTC)

--- a/tests/checks/test_base_run.py
+++ b/tests/checks/test_base_run.py
@@ -1,0 +1,172 @@
+"""
+Tests for the shared ``BaseCheck.run`` loop.
+
+These cover the cross-cutting behaviour that lives in the base class rather than
+in any individual check:
+
+  * the open PRs are snapshotted (pagination fully consumed) *before* any PR is
+    processed, so mutating a PR mid-run cannot reorder later pages and skip PRs;
+  * a failure on one PR does not abort the rest of the sweep;
+  * a secondary rate limit is retried after backing off, and a primary rate
+    limit stops the run.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from github.GithubException import RateLimitExceededException
+
+from ruciobot.checks.base import MAX_SECONDARY_RATE_LIMIT_RETRIES, BaseCheck
+
+
+def _make_pr(number):
+    pr = MagicMock()
+    pr.number = number
+    return pr
+
+
+class RecordingPulls:
+    """Mimics a PaginatedList: yields PRs lazily and records when each is pulled.
+
+    Used to prove that ``run`` exhausts pagination before processing any PR.
+    """
+
+    def __init__(self, prs, log):
+        self._prs = prs
+        self._log = log
+
+    def __iter__(self):
+        for pr in self._prs:
+            self._log.append(("fetched", pr.number))
+            yield pr
+
+
+class DummyCheck(BaseCheck):
+    """A check whose per-PR behaviour is scripted for testing."""
+
+    summary = "dummy check"
+
+    def __init__(self, log, behaviour=None):
+        self.log = log
+        self.behaviour = behaviour or {}
+
+    def process(self, pr, repo):
+        self.log.append(("processed", pr.number))
+        action = self.behaviour.get(pr.number)
+        if action is not None:
+            action()
+
+
+def _make_gh(prs, log):
+    repo = MagicMock()
+    repo.get_pulls.return_value = RecordingPulls(prs, log)
+    gh = MagicMock()
+    gh.get_repo.return_value = repo
+    return gh, repo
+
+
+def _secondary_exc(retry_after="1"):
+    headers = {"retry-after": retry_after} if retry_after is not None else {}
+    return RateLimitExceededException(
+        403,
+        {"message": "You have exceeded a secondary rate limit."},
+        headers,
+        None,
+    )
+
+
+def _primary_exc():
+    return RateLimitExceededException(
+        403, {"message": "API rate limit exceeded for user 123."}, {}, None
+    )
+
+
+class TestBaseRun(unittest.TestCase):
+    def test_fetches_all_open_prs_before_processing_any(self):
+        """run() must snapshot every open PR before mutating, so none is skipped."""
+        log = []
+        prs = [_make_pr(1), _make_pr(2), _make_pr(3)]
+        gh, repo = _make_gh(prs, log)
+
+        DummyCheck(log).run(gh, "rucio/rucio")
+
+        repo.get_pulls.assert_called_once_with(state="open")
+        # Every "fetched" entry must precede the first "processed" entry.
+        kinds = [kind for kind, _ in log]
+        first_processed = kinds.index("processed")
+        self.assertNotIn("fetched", kinds[first_processed:])
+        # And all three PRs were processed.
+        processed = [n for kind, n in log if kind == "processed"]
+        self.assertEqual(processed, [1, 2, 3])
+
+    def test_one_pr_failure_does_not_abort_the_sweep(self):
+        """A generic error on one PR must not stop the others from processing."""
+        log = []
+        prs = [_make_pr(1), _make_pr(2), _make_pr(3)]
+        gh, _ = _make_gh(prs, log)
+
+        def boom():
+            raise ValueError("kaboom")
+
+        DummyCheck(log, behaviour={2: boom}).run(gh, "rucio/rucio")
+
+        processed = [n for kind, n in log if kind == "processed"]
+        self.assertEqual(processed, [1, 2, 3])
+
+    @patch("ruciobot.checks.base.time.sleep")
+    def test_retries_then_succeeds_on_secondary_rate_limit(self, mock_sleep):
+        """A secondary rate limit is retried after backing off, then succeeds."""
+        log = []
+        prs = [_make_pr(1), _make_pr(2)]
+        gh, _ = _make_gh(prs, log)
+
+        state = {"raised": False}
+
+        def flaky():
+            if not state["raised"]:
+                state["raised"] = True
+                raise _secondary_exc(retry_after="1")
+
+        DummyCheck(log, behaviour={1: flaky}).run(gh, "rucio/rucio")
+
+        mock_sleep.assert_called_once_with(1)
+        processed = [n for kind, n in log if kind == "processed"]
+        # PR 1 processed twice (initial failure + successful retry), PR 2 once.
+        self.assertEqual(processed, [1, 1, 2])
+
+    @patch("ruciobot.checks.base.time.sleep")
+    def test_persistent_secondary_limit_skips_pr_and_continues(self, mock_sleep):
+        """If a PR keeps hitting the secondary limit, skip it and move on."""
+        log = []
+        prs = [_make_pr(1), _make_pr(2)]
+        gh, _ = _make_gh(prs, log)
+
+        def always():
+            raise _secondary_exc(retry_after="1")
+
+        DummyCheck(log, behaviour={1: always}).run(gh, "rucio/rucio")
+
+        self.assertEqual(mock_sleep.call_count, MAX_SECONDARY_RATE_LIMIT_RETRIES)
+        # PR 2 is still processed despite PR 1 exhausting its retries.
+        self.assertIn(2, [n for kind, n in log if kind == "processed"])
+
+    @patch("ruciobot.checks.base.time.sleep")
+    def test_primary_rate_limit_stops_the_run(self, mock_sleep):
+        """A primary rate limit halts the sweep, since nothing else can succeed."""
+        log = []
+        prs = [_make_pr(1), _make_pr(2), _make_pr(3)]
+        gh, _ = _make_gh(prs, log)
+
+        def primary():
+            raise _primary_exc()
+
+        DummyCheck(log, behaviour={2: primary}).run(gh, "rucio/rucio")
+
+        mock_sleep.assert_not_called()
+        processed = [n for kind, n in log if kind == "processed"]
+        # PR 1 and PR 2 attempted; PR 3 never reached.
+        self.assertEqual(processed, [1, 2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/checks/test_stale_prs.py
+++ b/tests/checks/test_stale_prs.py
@@ -1,234 +1,288 @@
 """
-Tests for stale PR check.
+Tests for the stale PR check.
 
-All `updated_at` and "now" values are pinned to a concrete Monday (2026-03-09)
-so that `count_business_days` returns deterministic results regardless of when
-the test suite is run.  This is necessary because the check uses business-day
-counting which is sensitive to which calendar day `updated_at` falls on.
+The check now distinguishes who a PR is waiting on:
 
-Anchor:
-  NOW = Monday 2026-03-09 12:00 UTC
+  * AUTHOR_BLOCKED  - a reviewer engaged and the author has not responded since;
+                      this is the only state that is marked stale and closed.
+  * AWAITING_REVIEW - never reviewed, a pending review request, or the author
+                      acted most recently; this is labeled ``needs-review`` and
+                      never closed for inactivity.
+  * APPROVED        - waiting on a merge; left alone.
 
-Business-day offsets from NOW (all going backwards in time):
-  1 bd  ago = Friday  2026-03-06  (Mon – skip Sat/Sun – Fri)
-  2 bds ago = Thursday 2026-03-05
-  5 bds ago = Monday  2026-03-02
-  7 bds ago = Thursday 2026-02-26
-  8 bds ago = Wednesday 2026-02-25
- 14 bds ago = Monday  2026-02-23  (exactly WARN_DAYS)
- 15 bds ago = Friday  2026-02-20  (WARN_DAYS + 1)
- 21 bds ago = Monday  2026-02-09  (CLOSE_DAYS=7 bds after WARN_DAYS: just testing CLOSE_DAYS)
+All timestamps are pinned to a concrete Monday (2026-03-09) so that
+``count_business_days`` is deterministic regardless of when the suite runs.
 """
 
 import unittest
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from ruciobot.checks.base import NO_BOT_LABEL
 from ruciobot.checks.stale_prs import (
     CLOSE_DAYS,
+    NEEDS_REVIEW_LABEL,
     STALE_LABEL,
     WARN_DAYS,
     process_pr,
 )
 
-# Pinned "now" for all tests — a Monday at noon UTC.
+# Pinned "now": a Monday at noon UTC.
 NOW = datetime(2026, 3, 9, 12, 0, tzinfo=UTC)
 
 
 def business_days_before(n: int, anchor: datetime = NOW) -> datetime:
-    """Return the datetime that is exactly *n* business days before *anchor*."""
+    """Return the datetime exactly *n* business days before *anchor*."""
     current = anchor
     counted = 0
     while counted < n:
         current -= timedelta(days=1)
-        if current.weekday() < 5:  # Mon–Fri
+        if current.weekday() < 5:  # Mon-Fri
             counted += 1
     return current
 
 
-# Pre-computed anchor offsets used across tests
-ACTIVE_DATE = business_days_before(2)  # 2 bds ago → Thu 2025-03-06 (< WARN_DAYS)
-STALE_WARN_DATE = business_days_before(WARN_DAYS + 1)  # 15 bds ago → well past threshold
-CLOSE_DATE = business_days_before(CLOSE_DAYS + 1)  # 8 bds ago → past CLOSE_DAYS (7)
-RECENT_DATE = business_days_before(1)  # 1 bd ago → Fri 2025-03-07
+# Anchored timestamps.
+RECENT = business_days_before(2)  # well within the stale threshold
+PAST_CLOSE = business_days_before(CLOSE_DAYS + 1)  # past the close threshold (8 bd)
+PAST_STALE = business_days_before(WARN_DAYS + 1)  # past the stale threshold (15 bd)
+OLD_REVIEW = business_days_before(20)
+OLD_COMMIT = business_days_before(40)
+
+
+# Mock builders
+
+
+class _PagedList(list):
+    """A list that also exposes PyGithub's ``totalCount`` attribute."""
+
+    @property
+    def totalCount(self) -> int:
+        return len(self)
+
+
+def _user(login):
+    return SimpleNamespace(login=login)
+
+
+def _review(state, login, submitted_at):
+    return SimpleNamespace(state=state, user=_user(login), submitted_at=submitted_at)
+
+
+def _commit(date):
+    return SimpleNamespace(commit=SimpleNamespace(committer=SimpleNamespace(date=date)))
+
+
+def _comment(login, created_at):
+    return SimpleNamespace(user=_user(login), created_at=created_at)
+
+
+def make_pr(
+    *,
+    updated_at,
+    labels=None,
+    author="alice",
+    reviews=None,
+    requested_users=None,
+    requested_teams=0,
+    commits=None,
+    comments=None,
+    number=1,
+):
+    pr = MagicMock()
+    pr.number = number
+    pr.title = f"PR {number}"
+    pr.updated_at = updated_at
+    pr.user = _user(author) if author else None
+    pr.labels = [SimpleNamespace(name=name) for name in (labels or [])]
+    pr.get_reviews.return_value = list(reviews or [])
+    users = _PagedList(_user(u) for u in (requested_users or []))
+    teams = _PagedList(None for _ in range(requested_teams))
+    pr.get_review_requests.return_value = (users, teams)
+    pr.get_commits.return_value = list(commits or [])
+    pr.get_issue_comments.return_value = list(comments or [])
+    return pr
+
+
+def run_check(pr, now=NOW):
+    with patch("ruciobot.checks.stale_prs.datetime") as mock_dt:
+        mock_dt.now.return_value = now
+        process_pr(pr, WARN_DAYS)
 
 
 class TestStalePRs(unittest.TestCase):
-    def _mock_now(self, mock_dt):
-        """Configure the datetime mock to return NOW for datetime.now()."""
-        mock_dt.now.return_value = NOW
+    # Author-blocked: the only state that is staled and closed.
 
-    def create_mock_pr(
-        self,
-        number,
-        updated_at,
-        labels=[],
-        pending_reviewers=0,
-        pending_teams=0,
-        approved_reviews=0,
-    ):
-        pr = MagicMock()
-        pr.number = number
-        pr.title = f"PR {number}"
-        pr.updated_at = updated_at
-
-        label_mocks = [MagicMock(name=lbl) for lbl in labels]
-        for m, lbl in zip(label_mocks, labels):
-            m.name = lbl
-        pr.labels = label_mocks
-
-        users_requested = MagicMock()
-        users_requested.totalCount = pending_reviewers
-        teams_requested = MagicMock()
-        teams_requested.totalCount = pending_teams
-        pr.get_review_requests.return_value = (users_requested, teams_requested)
-
-        reviews = []
-        for _ in range(approved_reviews):
-            r = MagicMock()
-            r.state = "APPROVED"
-            reviews.append(r)
-        pr.get_reviews.return_value = reviews
-
-        return pr
-
-    # Core behaviour tests
-
-    def test_warns_inactive_pr(self):
-        """Inactive PR (> WARN_DAYS business days) with no pending reviewers gets warned."""
-        pr = self.create_mock_pr(1, updated_at=STALE_WARN_DATE, labels=[], pending_reviewers=0)
-        with patch("ruciobot.checks.stale_prs.datetime") as mock_dt:
-            self._mock_now(mock_dt)
-            process_pr(pr, WARN_DAYS)
-        pr.add_to_labels.assert_called_with(STALE_LABEL)
+    def test_marks_author_blocked_pr_stale(self):
+        """Reviewer requested changes, author silent since: mark stale."""
+        pr = make_pr(
+            updated_at=PAST_STALE,
+            reviews=[_review("CHANGES_REQUESTED", "bob", PAST_STALE)],
+            commits=[_commit(OLD_COMMIT)],
+        )
+        run_check(pr)
+        pr.add_to_labels.assert_called_once_with(STALE_LABEL)
         pr.create_issue_comment.assert_called_once()
-
-    def test_ignores_active_pr(self):
-        """Active PR (< WARN_DAYS business days) is ignored."""
-        pr = self.create_mock_pr(1, updated_at=ACTIVE_DATE, labels=[])
-        with patch("ruciobot.checks.stale_prs.datetime") as mock_dt:
-            self._mock_now(mock_dt)
-            process_pr(pr, WARN_DAYS)
-        pr.add_to_labels.assert_not_called()
-        pr.create_issue_comment.assert_not_called()
-
-    def test_closes_stale_pr(self):
-        """Stale-labeled PR with further inactivity past CLOSE_DAYS is closed."""
-        pr = self.create_mock_pr(1, updated_at=CLOSE_DATE, labels=[STALE_LABEL])
-        with patch("ruciobot.checks.stale_prs.datetime") as mock_dt:
-            self._mock_now(mock_dt)
-            process_pr(pr, WARN_DAYS)
-        pr.edit.assert_called_with(state="closed")
-        pr.create_issue_comment.assert_called()
-
-    def test_ignores_recently_active_stale_pr(self):
-        """Stale-labeled PR that was recently updated is NOT closed."""
-        pr = self.create_mock_pr(1, updated_at=ACTIVE_DATE, labels=[STALE_LABEL])
-        with patch("ruciobot.checks.stale_prs.datetime") as mock_dt:
-            self._mock_now(mock_dt)
-            process_pr(pr, WARN_DAYS)
         pr.edit.assert_not_called()
 
-    def test_skips_pr_awaiting_reviewer(self):
-        """Inactive PR with pending review requests is NOT marked stale."""
-        pr = self.create_mock_pr(1, updated_at=STALE_WARN_DATE, labels=[], pending_reviewers=1)
-        with patch("ruciobot.checks.stale_prs.datetime") as mock_dt:
-            self._mock_now(mock_dt)
-            process_pr(pr, WARN_DAYS)
+    def test_closes_author_blocked_stale_pr(self):
+        """A stale-labeled, still author-blocked PR past CLOSE_DAYS is closed."""
+        pr = make_pr(
+            updated_at=PAST_CLOSE,
+            labels=[STALE_LABEL],
+            reviews=[_review("CHANGES_REQUESTED", "bob", OLD_REVIEW)],
+            commits=[_commit(OLD_COMMIT)],
+        )
+        run_check(pr)
+        pr.edit.assert_called_once_with(state="closed")
+        pr.create_issue_comment.assert_called_once()
+
+    def test_does_not_close_author_blocked_pr_before_threshold(self):
+        """A stale-labeled author-blocked PR not yet past CLOSE_DAYS is left open."""
+        pr = make_pr(
+            updated_at=business_days_before(CLOSE_DAYS - 1),
+            labels=[STALE_LABEL],
+            reviews=[_review("CHANGES_REQUESTED", "bob", OLD_REVIEW)],
+            commits=[_commit(OLD_COMMIT)],
+        )
+        run_check(pr)
+        pr.edit.assert_not_called()
+
+    # Awaiting review: never closed for inactivity.
+
+    def test_never_reviewed_pr_is_flagged_not_staled(self):
+        """An inactive PR that has never been reviewed is labeled needs-review, not stale."""
+        pr = make_pr(updated_at=PAST_STALE, commits=[_commit(PAST_STALE)])
+        run_check(pr)
+        pr.add_to_labels.assert_called_once_with(NEEDS_REVIEW_LABEL)
+        pr.create_issue_comment.assert_not_called()
+        pr.edit.assert_not_called()
+
+    def test_author_responded_after_review_is_not_staled(self):
+        """Author pushed after the last review (the #8516 case): awaiting review, not stale."""
+        pr = make_pr(
+            updated_at=PAST_STALE,
+            reviews=[_review("COMMENTED", "bob", OLD_REVIEW)],
+            commits=[_commit(PAST_STALE)],  # author push is more recent than the review
+        )
+        run_check(pr)
+        pr.add_to_labels.assert_called_once_with(NEEDS_REVIEW_LABEL)
+        pr.edit.assert_not_called()
+        pr.create_issue_comment.assert_not_called()
+        # The stale path must not run.
+        self.assertNotIn(((STALE_LABEL,), {}), [c for c in pr.add_to_labels.call_args_list])
+
+    def test_pending_review_request_is_labeled_not_staled(self):
+        """An inactive PR with a pending review request is labeled needs-review, not stale."""
+        pr = make_pr(updated_at=PAST_STALE, requested_users=["bob"])
+        run_check(pr)
+        pr.add_to_labels.assert_called_once_with(NEEDS_REVIEW_LABEL)
+        pr.create_issue_comment.assert_not_called()
+        pr.edit.assert_not_called()
+
+    def test_already_labeled_awaiting_review_is_left_alone(self):
+        """A PR already labeled needs-review gets no further label or comment."""
+        pr = make_pr(
+            updated_at=PAST_STALE,
+            labels=[NEEDS_REVIEW_LABEL],
+            commits=[_commit(PAST_STALE)],
+        )
+        run_check(pr)
+        pr.create_issue_comment.assert_not_called()
         pr.add_to_labels.assert_not_called()
+        pr.edit.assert_not_called()
+
+    # Label transitions.
+
+    def test_clears_stale_label_when_author_responds(self):
+        """A stale PR where the author pushed after the review has the stale label lifted."""
+        pr = make_pr(
+            updated_at=RECENT,
+            labels=[STALE_LABEL],
+            reviews=[_review("CHANGES_REQUESTED", "bob", business_days_before(10))],
+            commits=[_commit(RECENT)],
+        )
+        run_check(pr)
+        pr.remove_from_labels.assert_called_once_with(STALE_LABEL)
+        pr.edit.assert_not_called()
+        pr.add_to_labels.assert_not_called()  # still within threshold, so no needs-review yet
         pr.create_issue_comment.assert_not_called()
 
-    def test_marks_stale_when_no_pending_reviewers(self):
-        """Inactive PR without pending reviewers IS marked stale."""
-        pr = self.create_mock_pr(1, updated_at=STALE_WARN_DATE, labels=[], pending_reviewers=0)
-        with patch("ruciobot.checks.stale_prs.datetime") as mock_dt:
-            self._mock_now(mock_dt)
-            process_pr(pr, WARN_DAYS)
-        pr.add_to_labels.assert_called_with(STALE_LABEL)
-        pr.create_issue_comment.assert_called_once()
+    def test_clears_needs_review_label_when_author_becomes_blocked(self):
+        """A needs-review PR that gets a fresh changes-request has the label removed."""
+        pr = make_pr(
+            updated_at=business_days_before(1),
+            labels=[NEEDS_REVIEW_LABEL],
+            reviews=[_review("CHANGES_REQUESTED", "bob", business_days_before(1))],
+            commits=[_commit(business_days_before(5))],
+        )
+        run_check(pr)
+        pr.remove_from_labels.assert_called_once_with(NEEDS_REVIEW_LABEL)
+        pr.add_to_labels.assert_not_called()
+        pr.edit.assert_not_called()
+        pr.create_issue_comment.assert_not_called()
+
+    # Approved: waiting on a merge.
+
+    def test_approved_pr_is_left_alone(self):
+        """An approved but unmerged PR is neither staled nor flagged."""
+        pr = make_pr(updated_at=PAST_STALE, reviews=[_review("APPROVED", "bob", OLD_REVIEW)])
+        run_check(pr)
+        pr.add_to_labels.assert_not_called()
+        pr.remove_from_labels.assert_not_called()
+        pr.create_issue_comment.assert_not_called()
+        pr.edit.assert_not_called()
+
+    def test_approved_pr_clears_needs_review_label(self):
+        """An approved PR still carrying needs-review has that label removed."""
+        pr = make_pr(
+            updated_at=PAST_STALE,
+            labels=[NEEDS_REVIEW_LABEL],
+            reviews=[_review("APPROVED", "bob", OLD_REVIEW)],
+        )
+        run_check(pr)
+        pr.remove_from_labels.assert_called_once_with(NEEDS_REVIEW_LABEL)
+        pr.add_to_labels.assert_not_called()
+        pr.edit.assert_not_called()
+
+    # Exclusions and gating.
 
     def test_skips_pr_with_no_bot_label(self):
-        """PR with 'no-bot' label is completely skipped by all stale checks."""
-        from ruciobot.checks.base import NO_BOT_LABEL
-
-        pr = self.create_mock_pr(1, updated_at=STALE_WARN_DATE, labels=[NO_BOT_LABEL])
-        with patch("ruciobot.checks.stale_prs.datetime") as mock_dt:
-            self._mock_now(mock_dt)
-            process_pr(pr, WARN_DAYS)
-        pr.add_to_labels.assert_not_called()
-        pr.create_issue_comment.assert_not_called()
-        pr.edit.assert_not_called()
-
-    def test_skips_pr_with_approved_review(self):
-        """Inactive PR that already has an approved review is NOT marked stale."""
-        pr = self.create_mock_pr(1, updated_at=STALE_WARN_DATE, labels=[], approved_reviews=1)
-        with patch("ruciobot.checks.stale_prs.datetime") as mock_dt:
-            self._mock_now(mock_dt)
-            process_pr(pr, WARN_DAYS)
-        pr.add_to_labels.assert_not_called()
-        pr.create_issue_comment.assert_not_called()
-
-    def test_removes_stale_label_when_reviewer_assigned_after_stale(self):
-        """Stale-labeled PR that later gets a reviewer assigned has stale label removed."""
-        pr = self.create_mock_pr(
-            1, updated_at=CLOSE_DATE, labels=[STALE_LABEL], pending_reviewers=1
+        """A no-bot PR is skipped entirely, before any classification."""
+        pr = make_pr(
+            updated_at=PAST_STALE,
+            labels=[NO_BOT_LABEL],
+            reviews=[_review("CHANGES_REQUESTED", "bob", OLD_REVIEW)],
         )
-        with patch("ruciobot.checks.stale_prs.datetime") as mock_dt:
-            self._mock_now(mock_dt)
-            process_pr(pr, WARN_DAYS)
-        pr.remove_from_labels.assert_called_with(STALE_LABEL)
+        run_check(pr)
+        pr.add_to_labels.assert_not_called()
+        pr.create_issue_comment.assert_not_called()
+        pr.edit.assert_not_called()
+        pr.get_reviews.assert_not_called()
+
+    def test_active_pr_short_circuits_without_api_calls(self):
+        """A recently active, unlabeled PR returns before any review/commit lookups."""
+        pr = make_pr(updated_at=RECENT)
+        run_check(pr)
+        pr.get_reviews.assert_not_called()
+        pr.get_commits.assert_not_called()
+        pr.add_to_labels.assert_not_called()
+        pr.create_issue_comment.assert_not_called()
         pr.edit.assert_not_called()
 
-    def test_removes_stale_label_when_approved_after_stale(self):
-        """Stale-labeled PR that later gets approved has stale label removed."""
-        pr = self.create_mock_pr(1, updated_at=CLOSE_DATE, labels=[STALE_LABEL], approved_reviews=1)
-        with patch("ruciobot.checks.stale_prs.datetime") as mock_dt:
-            self._mock_now(mock_dt)
-            process_pr(pr, WARN_DAYS)
-        pr.remove_from_labels.assert_called_with(STALE_LABEL)
-        pr.edit.assert_not_called()
-
-    # Weekend-aware tests
-
-    def test_does_not_warn_when_only_weekend_has_passed(self):
-        """PR pushed on a Friday; bot runs on Sunday — 0 business days elapsed, no warning.
-
-        Timeline:
-          - updated_at = Friday 2026-03-06 17:00 UTC
-          - "now"      = Sunday 2026-03-08 09:00 UTC
-          Business days between Fri 17:00 and Sun 09:00 = 0  (< WARN_DAYS=14).
-        """
+    def test_weekend_only_gap_takes_no_action(self):
+        """A Friday-to-Sunday gap is 0 business days, so nothing happens."""
         friday = datetime(2026, 3, 6, 17, 0, tzinfo=UTC)
         sunday = datetime(2026, 3, 8, 9, 0, tzinfo=UTC)
-
-        pr = self.create_mock_pr(1, updated_at=friday, labels=[])
-
-        with patch("ruciobot.checks.stale_prs.datetime") as mock_dt:
-            mock_dt.now.return_value = sunday
-            process_pr(pr, WARN_DAYS)
-
+        pr = make_pr(
+            updated_at=friday,
+            reviews=[_review("CHANGES_REQUESTED", "bob", business_days_before(10, friday))],
+        )
+        run_check(pr, now=sunday)
+        pr.get_reviews.assert_not_called()  # gated out by the business-day check
         pr.add_to_labels.assert_not_called()
-        pr.create_issue_comment.assert_not_called()
-
-    def test_warns_after_enough_business_days_spanning_weekend(self):
-        """PR pushed 3 weeks ago on a Monday; 15 business days elapsed → warn.
-
-        Timeline:
-          - updated_at = Monday 2026-02-16 09:00 UTC
-          - "now"      = Monday 2026-03-09 09:00 UTC
-          3 calendar weeks * 5 weekdays = 15 business days >= WARN_DAYS (14).
-        """
-        three_weeks_ago = datetime(2026, 2, 16, 9, 0, tzinfo=UTC)
-        now_monday = datetime(2026, 3, 9, 9, 0, tzinfo=UTC)
-
-        pr = self.create_mock_pr(1, updated_at=three_weeks_ago, labels=[])
-
-        with patch("ruciobot.checks.stale_prs.datetime") as mock_dt:
-            mock_dt.now.return_value = now_monday
-            process_pr(pr, WARN_DAYS)
-
-        pr.add_to_labels.assert_called_with(STALE_LABEL)
-        pr.create_issue_comment.assert_called_once()
+        pr.edit.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Only to review the latest commit, the other one is dealt with in a separate PR.

feat(checks): Only mark a PR stale when it is waiting on the author

The stale check treated "no pending review request" as "not awaiting
review", so it marked stale, and eventually closed, any PR that had
been inactive long enough. But GitHub clears the review-request state
as soon as a reviewer leaves comments, and restores it only on a
manual re-request. A PR that was ready and waiting on the maintainers
(CI green, review comments addressed, no approval yet) therefore looked
identical to an abandoned one and was closed for the maintainers'
inactivity. PR rucio/rucio#8516 is an example, and is itself a
resubmission of rucio/rucio#8289, which was auto-closed the same way.

Decide who the PR is waiting on before acting:

- author-blocked: a reviewer engaged (changes requested or commented)
  more recently than the author last pushed or commented. Only these
  PRs are marked stale and closed, with the same 14 + 7 weekday timing.
- awaiting review: never reviewed, a pending review request, or the
  author acted most recently. These are never closed by this check;
  they get a needs-review label and a single nudge for reviewers.
- approved: left alone, as it is waiting on a merge.

This governs only the inactivity path. The separate failing-tests
check is unchanged, so a PR with persistently failing CI is still
closed by that check regardless of who it is waiting on.

Labels are kept in sync: stale is lifted once a PR is no longer
author-blocked, and needs-review is removed once the ball returns to
the author or the PR is approved. The court check is gated behind the
inactivity threshold so it adds no API calls for active PRs.

Rewrite tests/checks/test_stale_prs.py around the three states, update
the README, and add a needs-review label note.

Assisted-by: Claude Opus 4.8 (Anthropic)