### PR TITLE
feat(checks): Ignore PRs opened by Dependabot

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Responsible for PR merging in [rucio/ruciobot](https://github.com/rucio/ruciobot
 
 **Needs rebase.** A pull request that has merge conflicts with its target branch receives a comment asking the author to rebase, and is labeled `needs-rebase`. Once the conflicts are resolved, the label is removed automatically on the next run.
 
-PRs labeled `no-bot` are excluded from all checks. More checks will be added over time. To request a new feature or report a bug, please open an issue.
+PRs opened by [Dependabot](https://docs.github.com/en/code-security/dependabot) and PRs labeled `no-bot` are excluded from all checks. More checks will be added over time. To request a new feature or report a bug, please open an issue.
 
 ## Running the bot
 

--- a/ruciobot/checks/base.py
+++ b/ruciobot/checks/base.py
@@ -22,10 +22,32 @@ MAX_SECONDARY_RATE_LIMIT_RETRIES = 3
 DEFAULT_RETRY_AFTER_SECONDS = 60
 MAX_RETRY_AFTER_SECONDS = 300  # cap, so an oversized Retry-After cannot hang the job
 
+# Logins Dependabot uses to open PRs. Dependency-update PRs are managed by
+# Dependabot itself, so the bot leaves them alone: it must not mark them stale,
+# nag them to rebase, or close them for failing tests.
+DEPENDABOT_LOGINS = frozenset({"dependabot[bot]", "dependabot-preview[bot]"})
 
-def is_excluded_from_bot(pr) -> bool:
-    """Return True if the PR carries the no-bot exclusion label."""
-    return NO_BOT_LABEL in [lbl.name for lbl in pr.labels]
+
+def is_dependabot_pr(pr) -> bool:
+    """Return True if the PR was opened by Dependabot."""
+    user = getattr(pr, "user", None)
+    login = getattr(user, "login", None)
+    return login in DEPENDABOT_LOGINS
+
+
+def exclusion_reason(pr) -> str | None:
+    """Return why the bot should skip *pr*, or ``None`` if it should not.
+
+    A PR is excluded from every bot check when it was opened by Dependabot or
+    when it carries the ``no-bot`` label. The returned string is phrased to read
+    naturally after the PR reference in a log line, e.g.
+    ``PR #5 was opened by Dependabot``.
+    """
+    if is_dependabot_pr(pr):
+        return "was opened by Dependabot"
+    if NO_BOT_LABEL in [lbl.name for lbl in pr.labels]:
+        return f"has '{NO_BOT_LABEL}' label"
+    return None
 
 
 def count_business_days(start: datetime, end: datetime) -> int:

--- a/ruciobot/checks/failing_tests.py
+++ b/ruciobot/checks/failing_tests.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from github.PullRequest import PullRequest
 from github.Repository import Repository
 
-from .base import NO_BOT_LABEL, BaseCheck, count_business_days, is_excluded_from_bot
+from .base import BaseCheck, count_business_days, exclusion_reason
 
 FAILING_TESTS_LABEL = "failing-tests"
 FAILING_TESTS_WARN_DAYS = 1  # Days of inactivity before warning
@@ -28,8 +28,9 @@ class FailingTestsCheck(BaseCheck):
 
 def process_failing_test_pr(pr: PullRequest, repo) -> None:
     """Process a single PR to check for failing tests and apply warn/close logic."""
-    if is_excluded_from_bot(pr):
-        print(f"  [SKIP] PR #{pr.number} has '{NO_BOT_LABEL}' label. Skipping.")
+    reason = exclusion_reason(pr)
+    if reason:
+        print(f"  [SKIP] PR #{pr.number} {reason}. Skipping.")
         return
     now = datetime.now(UTC)
     assert pr.updated_at is not None, f"PR #{pr.number} has no updated_at timestamp"

--- a/ruciobot/checks/needs_rebase.py
+++ b/ruciobot/checks/needs_rebase.py
@@ -5,7 +5,7 @@ Needs-rebase check: comment on PRs that cannot be merged due to conflicts.
 from github.PullRequest import PullRequest
 from github.Repository import Repository
 
-from .base import NO_BOT_LABEL, BaseCheck, is_excluded_from_bot
+from .base import BaseCheck, exclusion_reason
 
 NEEDS_REBASE_LABEL = "needs-rebase"
 
@@ -31,8 +31,9 @@ class NeedsRebaseCheck(BaseCheck):
 
 def process_needs_rebase_pr(pr: PullRequest) -> None:
     """Comment on and label a PR if it has unresolved merge conflicts."""
-    if is_excluded_from_bot(pr):
-        print(f"  [SKIP] PR #{pr.number} has '{NO_BOT_LABEL}' label. Skipping.")
+    reason = exclusion_reason(pr)
+    if reason:
+        print(f"  [SKIP] PR #{pr.number} {reason}. Skipping.")
         return
 
     mergeable = pr.mergeable  # None = GitHub hasn't computed it yet; False = conflicts

--- a/ruciobot/checks/stale_prs.py
+++ b/ruciobot/checks/stale_prs.py
@@ -15,7 +15,7 @@ from datetime import UTC, datetime
 from github.PullRequest import PullRequest
 from github.Repository import Repository
 
-from .base import NO_BOT_LABEL, BaseCheck, count_business_days, is_excluded_from_bot
+from .base import BaseCheck, count_business_days, exclusion_reason
 
 STALE_LABEL = "stale"
 NEEDS_REVIEW_LABEL = "needs-review"
@@ -47,8 +47,9 @@ class StalePRCheck(BaseCheck):
 
 def process_pr(pr: PullRequest, days_until_stale: int) -> None:
     """Apply the stale / needs-review logic to a single PR."""
-    if is_excluded_from_bot(pr):
-        print(f"  [SKIP] PR #{pr.number} has '{NO_BOT_LABEL}' label. Skipping.")
+    reason = exclusion_reason(pr)
+    if reason:
+        print(f"  [SKIP] PR #{pr.number} {reason}. Skipping.")
         return
 
     now = datetime.now(UTC)

--- a/tests/checks/test_base.py
+++ b/tests/checks/test_base.py
@@ -1,0 +1,70 @@
+"""
+Tests for the shared exclusion helpers in ``base`` that decide whether the bot
+should touch a PR at all: PRs opened by Dependabot and PRs carrying the no-bot
+label are skipped by every check.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from ruciobot.checks.base import (
+    NO_BOT_LABEL,
+    exclusion_reason,
+    is_dependabot_pr,
+)
+
+
+def _make_pr(login=None, labels=()):
+    pr = MagicMock()
+    pr.user = None if login is None else MagicMock(login=login)
+    label_mocks = []
+    for lbl in labels:
+        m = MagicMock()
+        m.name = lbl
+        label_mocks.append(m)
+    pr.labels = label_mocks
+    return pr
+
+
+class TestIsDependabotPR(unittest.TestCase):
+    def test_recognises_dependabot(self):
+        self.assertTrue(is_dependabot_pr(_make_pr(login="dependabot[bot]")))
+
+    def test_recognises_legacy_dependabot_preview(self):
+        self.assertTrue(is_dependabot_pr(_make_pr(login="dependabot-preview[bot]")))
+
+    def test_regular_author_is_not_dependabot(self):
+        self.assertFalse(is_dependabot_pr(_make_pr(login="octocat")))
+
+    def test_lookalike_author_is_not_dependabot(self):
+        """Only the exact bot logins count, not a human who mimics the name."""
+        self.assertFalse(is_dependabot_pr(_make_pr(login="dependabot")))
+
+    def test_missing_user_is_not_dependabot(self):
+        """A PR from a deleted account (user is None) must not blow up."""
+        self.assertFalse(is_dependabot_pr(_make_pr(login=None)))
+
+
+class TestExclusionReason(unittest.TestCase):
+    def test_dependabot_pr_is_excluded(self):
+        self.assertEqual(
+            exclusion_reason(_make_pr(login="dependabot[bot]")),
+            "was opened by Dependabot",
+        )
+
+    def test_no_bot_label_pr_is_excluded(self):
+        self.assertEqual(
+            exclusion_reason(_make_pr(login="octocat", labels=[NO_BOT_LABEL])),
+            f"has '{NO_BOT_LABEL}' label",
+        )
+
+    def test_dependabot_takes_precedence_over_label(self):
+        reason = exclusion_reason(_make_pr(login="dependabot[bot]", labels=[NO_BOT_LABEL]))
+        self.assertEqual(reason, "was opened by Dependabot")
+
+    def test_regular_pr_is_not_excluded(self):
+        self.assertIsNone(exclusion_reason(_make_pr(login="octocat", labels=["enhancement"])))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/checks/test_failing_tests.py
+++ b/tests/checks/test_failing_tests.py
@@ -171,6 +171,18 @@ class TestFailingTestPRs(unittest.TestCase):
         pr.create_issue_comment.assert_not_called()
         pr.edit.assert_not_called()
 
+    def test_skips_dependabot_pr(self):
+        """PR opened by Dependabot is skipped, even with failing tests and inactivity."""
+        pr = self.create_mock_pr(1, updated_at=WARN_DATE, labels=[])
+        pr.user.login = "dependabot[bot]"
+        repo = self.create_mock_repo(["failure"])
+        with patch("ruciobot.checks.failing_tests.datetime") as mock_dt:
+            self._mock_now(mock_dt)
+            process_failing_test_pr(pr, repo)
+        pr.add_to_labels.assert_not_called()
+        pr.create_issue_comment.assert_not_called()
+        pr.edit.assert_not_called()
+
     # Weekend-aware tests
 
     def test_does_not_warn_when_only_weekend_has_passed(self):

--- a/tests/checks/test_needs_rebase.py
+++ b/tests/checks/test_needs_rebase.py
@@ -73,6 +73,15 @@ class TestNeedsRebaseCheck(unittest.TestCase):
         pr.create_issue_comment.assert_not_called()
         pr.add_to_labels.assert_not_called()
 
+    # Dependabot author : skipped regardless of merge state
+    def test_skips_dependabot_pr(self):
+        """PR opened by Dependabot is skipped, even if it has conflicts."""
+        pr = self._make_pr(7, mergeable=False)
+        pr.user.login = "dependabot[bot]"
+        process_needs_rebase_pr(pr)
+        pr.create_issue_comment.assert_not_called()
+        pr.add_to_labels.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/checks/test_stale_prs.py
+++ b/tests/checks/test_stale_prs.py
@@ -261,6 +261,19 @@ class TestStalePRs(unittest.TestCase):
         pr.edit.assert_not_called()
         pr.get_reviews.assert_not_called()
 
+    def test_skips_dependabot_pr(self):
+        """A Dependabot PR is skipped entirely, before any classification."""
+        pr = make_pr(
+            updated_at=PAST_STALE,
+            author="dependabot[bot]",
+            reviews=[_review("CHANGES_REQUESTED", "bob", OLD_REVIEW)],
+        )
+        run_check(pr)
+        pr.add_to_labels.assert_not_called()
+        pr.create_issue_comment.assert_not_called()
+        pr.edit.assert_not_called()
+        pr.get_reviews.assert_not_called()
+
     def test_active_pr_short_circuits_without_api_calls(self):
         """A recently active, unlabeled PR returns before any review/commit lookups."""
         pr = make_pr(updated_at=RECENT)


### PR DESCRIPTION
Dependency-update PRs are managed by Dependabot itself and should not be marked stale, nagged to rebase, or closed for failing tests. They are now excluded from every check, alongside the existing no-bot label.

The shared exclusion check is consolidated into exclusion_reason(), which reports *why* a PR is skipped, so each [SKIP] log line names the actual reason (Dependabot or the no-bot label) instead of always claiming the no-bot label.

Assisted-By: Claude Opus 4.8