### PR TITLE
feat(checks): Ignore draft pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Responsible for PR merging in [rucio/ruciobot](https://github.com/rucio/ruciobot
 
 **Needs rebase.** A pull request that has merge conflicts with its target branch receives a comment asking the author to rebase, and is labeled `needs-rebase`. Once the conflicts are resolved, the label is removed automatically on the next run.
 
-PRs opened by [Dependabot](https://docs.github.com/en/code-security/dependabot) and PRs labeled `no-bot` are excluded from all checks. More checks will be added over time. To request a new feature or report a bug, please open an issue.
+Draft pull requests, PRs opened by [Dependabot](https://docs.github.com/en/code-security/dependabot), and PRs labeled `no-bot` are excluded from all checks. More checks will be added over time. To request a new feature or report a bug, please open an issue.
 
 ## Running the bot
 

--- a/ruciobot/checks/base.py
+++ b/ruciobot/checks/base.py
@@ -35,16 +35,28 @@ def is_dependabot_pr(pr) -> bool:
     return login in DEPENDABOT_LOGINS
 
 
+def is_draft_pr(pr) -> bool:
+    """Return True if the PR is still a draft.
+
+    Draft PRs are explicitly marked work in progress, so nothing is owed by the
+    author yet. ``PullRequest.draft`` is a plain bool on real PRs; the default
+    keeps this safe for objects that do not set the attribute.
+    """
+    return getattr(pr, "draft", False) is True
+
+
 def exclusion_reason(pr) -> str | None:
     """Return why the bot should skip *pr*, or ``None`` if it should not.
 
-    A PR is excluded from every bot check when it was opened by Dependabot or
-    when it carries the ``no-bot`` label. The returned string is phrased to read
-    naturally after the PR reference in a log line, e.g.
+    A PR is excluded from every bot check when it was opened by Dependabot, is
+    still a draft, or carries the ``no-bot`` label. The returned string is
+    phrased to read naturally after the PR reference in a log line, e.g.
     ``PR #5 was opened by Dependabot``.
     """
     if is_dependabot_pr(pr):
         return "was opened by Dependabot"
+    if is_draft_pr(pr):
+        return "is a draft"
     if NO_BOT_LABEL in [lbl.name for lbl in pr.labels]:
         return f"has '{NO_BOT_LABEL}' label"
     return None

--- a/tests/checks/test_base.py
+++ b/tests/checks/test_base.py
@@ -1,7 +1,7 @@
 """
 Tests for the shared exclusion helpers in ``base`` that decide whether the bot
-should touch a PR at all: PRs opened by Dependabot and PRs carrying the no-bot
-label are skipped by every check.
+should touch a PR at all: PRs opened by Dependabot, draft PRs, and PRs carrying
+the no-bot label are skipped by every check.
 """
 
 import unittest
@@ -11,12 +11,14 @@ from ruciobot.checks.base import (
     NO_BOT_LABEL,
     exclusion_reason,
     is_dependabot_pr,
+    is_draft_pr,
 )
 
 
-def _make_pr(login=None, labels=()):
+def _make_pr(login=None, labels=(), draft=False):
     pr = MagicMock()
     pr.user = None if login is None else MagicMock(login=login)
+    pr.draft = draft
     label_mocks = []
     for lbl in labels:
         m = MagicMock()
@@ -45,12 +47,27 @@ class TestIsDependabotPR(unittest.TestCase):
         self.assertFalse(is_dependabot_pr(_make_pr(login=None)))
 
 
+class TestIsDraftPR(unittest.TestCase):
+    def test_draft_pr_is_recognised(self):
+        self.assertTrue(is_draft_pr(_make_pr(draft=True)))
+
+    def test_ready_pr_is_not_a_draft(self):
+        self.assertFalse(is_draft_pr(_make_pr(draft=False)))
+
+    def test_missing_draft_attribute_is_not_a_draft(self):
+        """A non-bool/absent ``draft`` must be treated as not-draft, never truthy."""
+        self.assertFalse(is_draft_pr(object()))
+
+
 class TestExclusionReason(unittest.TestCase):
     def test_dependabot_pr_is_excluded(self):
         self.assertEqual(
             exclusion_reason(_make_pr(login="dependabot[bot]")),
             "was opened by Dependabot",
         )
+
+    def test_draft_pr_is_excluded(self):
+        self.assertEqual(exclusion_reason(_make_pr(login="octocat", draft=True)), "is a draft")
 
     def test_no_bot_label_pr_is_excluded(self):
         self.assertEqual(
@@ -61,6 +78,10 @@ class TestExclusionReason(unittest.TestCase):
     def test_dependabot_takes_precedence_over_label(self):
         reason = exclusion_reason(_make_pr(login="dependabot[bot]", labels=[NO_BOT_LABEL]))
         self.assertEqual(reason, "was opened by Dependabot")
+
+    def test_draft_takes_precedence_over_label(self):
+        reason = exclusion_reason(_make_pr(login="octocat", labels=[NO_BOT_LABEL], draft=True))
+        self.assertEqual(reason, "is a draft")
 
     def test_regular_pr_is_not_excluded(self):
         self.assertIsNone(exclusion_reason(_make_pr(login="octocat", labels=["enhancement"])))

--- a/tests/checks/test_failing_tests.py
+++ b/tests/checks/test_failing_tests.py
@@ -183,6 +183,18 @@ class TestFailingTestPRs(unittest.TestCase):
         pr.create_issue_comment.assert_not_called()
         pr.edit.assert_not_called()
 
+    def test_skips_draft_pr(self):
+        """A draft PR is skipped, even with failing tests and inactivity."""
+        pr = self.create_mock_pr(1, updated_at=WARN_DATE, labels=[])
+        pr.draft = True
+        repo = self.create_mock_repo(["failure"])
+        with patch("ruciobot.checks.failing_tests.datetime") as mock_dt:
+            self._mock_now(mock_dt)
+            process_failing_test_pr(pr, repo)
+        pr.add_to_labels.assert_not_called()
+        pr.create_issue_comment.assert_not_called()
+        pr.edit.assert_not_called()
+
     # Weekend-aware tests
 
     def test_does_not_warn_when_only_weekend_has_passed(self):

--- a/tests/checks/test_needs_rebase.py
+++ b/tests/checks/test_needs_rebase.py
@@ -82,6 +82,15 @@ class TestNeedsRebaseCheck(unittest.TestCase):
         pr.create_issue_comment.assert_not_called()
         pr.add_to_labels.assert_not_called()
 
+    # Draft PR : skipped regardless of merge state
+    def test_skips_draft_pr(self):
+        """A draft PR is skipped, even if it has conflicts."""
+        pr = self._make_pr(8, mergeable=False)
+        pr.draft = True
+        process_needs_rebase_pr(pr)
+        pr.create_issue_comment.assert_not_called()
+        pr.add_to_labels.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/checks/test_stale_prs.py
+++ b/tests/checks/test_stale_prs.py
@@ -274,6 +274,19 @@ class TestStalePRs(unittest.TestCase):
         pr.edit.assert_not_called()
         pr.get_reviews.assert_not_called()
 
+    def test_skips_draft_pr(self):
+        """A draft PR is skipped entirely, before any classification."""
+        pr = make_pr(
+            updated_at=PAST_STALE,
+            reviews=[_review("CHANGES_REQUESTED", "bob", OLD_REVIEW)],
+        )
+        pr.draft = True
+        run_check(pr)
+        pr.add_to_labels.assert_not_called()
+        pr.create_issue_comment.assert_not_called()
+        pr.edit.assert_not_called()
+        pr.get_reviews.assert_not_called()
+
     def test_active_pr_short_circuits_without_api_calls(self):
         """A recently active, unlabeled PR returns before any review/commit lookups."""
         pr = make_pr(updated_at=RECENT)


### PR DESCRIPTION
Draft PRs are explicitly marked work in progress: nothing is owed by the author yet, so the bot must not mark them stale, nag them to rebase, or close them for failing tests. They are now excluded from every check, alongside Dependabot PRs and the no-bot label, via the shared exclusion_reason() helper.

This closes a real gap: on rucio/rucio the bot repeatedly closed draft PRs (one was closed five times before a maintainer applied no-bot to stop it).

Assisted-By: Claude Opus 4.8